### PR TITLE
Fixes according to chapter Lexical of the Language Reference

### DIFF
--- a/D.g4
+++ b/D.g4
@@ -199,8 +199,8 @@ Comment : (BlockComment | LineComment | NestingBlockComment) -> skip;
 
 Identifier : ([a-zA-Z_])([a-zA-Z0-9_])*;
 
-fragment WysiwygString : 'r"' '"' StringPostfix?;
-fragment AlternativeWysiwygString : '`' (~['`'])* '`' StringPostfix?;
+fragment WysiwygString : 'r"' .*? '"' StringPostfix?;
+fragment AlternativeWysiwygString : '`' .*? '`' StringPostfix?;
 fragment EscapeSequence : '\\\''
     | '\\"'
     | '\\\\'

--- a/D.g4
+++ b/D.g4
@@ -193,7 +193,7 @@ fragment BinDigit: [01];
 fragment DecimalDigit: [0-9];
 
 fragment BlockComment: '/*' .*? '*/';
-fragment LineComment: '//' (~[\r\n])* EndOfLine;
+fragment LineComment: '//' (~[\u000D\u000A\u2028\u2029])* EndOfLine?;
 fragment NestingBlockComment: '/+' (NestingBlockComment | .)*? '+/';
 Comment : (BlockComment | LineComment | NestingBlockComment) -> skip;
 

--- a/D.g4
+++ b/D.g4
@@ -204,6 +204,7 @@ fragment AlternativeWysiwygString : '`' .*? '`' StringPostfix?;
 fragment EscapeSequence : '\\\''
     | '\\"'
     | '\\\\'
+    | '\\?'
     | '\\0'
     | '\\a'
     | '\\b'
@@ -213,8 +214,7 @@ fragment EscapeSequence : '\\\''
     | '\\t'
     | '\\v'
     | '\\x' HexDigit HexDigit
-    | '\\' OctalDigit OctalDigit
-    | '\\' OctalDigit OctalDigit OctalDigit
+    | '\\' OctalDigit OctalDigit? OctalDigit?
     | '\\u' HexDigit HexDigit HexDigit HexDigit
     | '\\U' HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit
     | '\\&' Character+ ';';

--- a/D.g4
+++ b/D.g4
@@ -193,7 +193,7 @@ fragment BinDigit: [01];
 fragment DecimalDigit: [0-9];
 
 fragment BlockComment: '/*' .*? '*/';
-fragment LineComment: '//' (~[\u000D\u000A\u2028\u2029])* EndOfLine?;
+fragment LineComment: '//' (~[\u000D\u000A\u2028\u2029])* (EndOfLine | EOF);
 fragment NestingBlockComment: '/+' (NestingBlockComment | .)*? '+/';
 Comment : (BlockComment | LineComment | NestingBlockComment) -> skip;
 
@@ -251,7 +251,8 @@ fragment ImaginarySuffix: 'i';
 fragment HexFloat: ('0x' | '0X') ((HexDigit (HexDigit | '_')* '.' HexDigit (HexDigit | '_')*) | ('.' HexDigit (HexDigit | '_')*) | (HexDigit (HexDigit | '_')*)) HexExponent;
 fragment HexExponent: ('p' | 'P' | 'p+' | 'P+' | 'p-' | 'P-') DecimalDigit (DecimalDigit | '_')*;
 
-SpecialTokenSequence: ('#line' IntegerLiteral ('"' Character+ '"')? EndOfLine) -> skip;
+SpecialTokenSequence: '#line' Space+ IntegerLiteral Space* ('"' .*? '"' Space*)? (EndOfLine | EOF) -> skip;
+fragment Space: [\u0020\u0009\u000B\u000C];
 
 module: moduleDeclaration? declaration*
     ;

--- a/D.g4
+++ b/D.g4
@@ -239,7 +239,11 @@ fragment HexadecimalInteger: ('0x' | '0X') HexDigit (HexDigit | '_')*;
 
 FloatLiteral: (FloatOption (FloatSuffix | RealSuffix)?) | (Integer (FloatSuffix | RealSuffix)? ImaginarySuffix);
 fragment FloatOption: DecimalFloat | HexFloat;
-fragment DecimalFloat: (DecimalInteger '.' DecimalDigit*); /* BUG: can't lex a[0..1] properly */
+fragment DecimalFloat
+    : DecimalInteger '.' (DecimalDigit (DecimalDigit | '_')* DecimalExponent?)?  // BUG: can't lex a[0..1] properly
+    | '.' DecimalInteger DecimalExponent?
+    | DecimalInteger DecimalExponent
+    ;
 fragment DecimalExponent: ('e' | 'E' | 'e+' | 'E+' | 'e-' | 'E-') DecimalInteger;
 fragment FloatSuffix: 'F' | 'f';
 fragment RealSuffix: 'L';

--- a/D.g4
+++ b/D.g4
@@ -217,7 +217,7 @@ fragment EscapeSequence : '\\\''
     | '\\' OctalDigit OctalDigit? OctalDigit?
     | '\\u' HexDigit HexDigit HexDigit HexDigit
     | '\\U' HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit
-    | '\\&' Character+ ';';
+    | '\\&' Identifier ';';
 fragment HexStringChar : [0-9a-fA-F] | Whitespace | EndOfLine;
 fragment StringPostfix : [dwc];
 fragment DoubleQuotedCharacter : EscapeSequence | ~('"' | '\\' );


### PR DESCRIPTION
- line comment is not recognized at end of file
- `WysiwygString` with non-empty content is not recognized
- escape sequence `\?` is not recognized
- escape sequence with single octal digit is not recognized
- named character entities are not recognized
- `DecimalFloat` is not recognized when it starts with `.` or does not contain `.`
- `SpecialTokenSequence` is very special:
  the compiler requires `#line 42` instead of `#line42` and allows `#line 42 (foo)`

By the way: why don't you use a grammar rule `stringLiterals` according to the chapter Expressions?
Your `StringFragment`s must also allow for comments or even `SpecialTokenSequence`s in between.
